### PR TITLE
Initialize _touchesCount variable

### DIFF
--- a/org/gesluxe/gestures/Gesture.hx
+++ b/org/gesluxe/gestures/Gesture.hx
@@ -85,6 +85,7 @@ class Gesture
 	{
 		preinit();
 		
+        _touchesCount = 0;
 		events = new Events();
 		_gesturesManager = Gesluxe.gesturesManager;
 		_touchesMap = new Map<Int, Touch>();


### PR DESCRIPTION
The gesture handling failed on the web target because `_touchesCount` would be uninitialized (i.e. `NaN`) in the JavaScript code.

Related to https://github.com/josuigoa/gesluxe/issues/3.
